### PR TITLE
Include Client's Input when an error occurs.

### DIFF
--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -49,7 +49,8 @@ impl LightClient for ParliaLightClient {
         any_client_state: Any,
         any_consensus_state: Any,
     ) -> Result<CreateClientResult, LightClientError> {
-        self.process_create_client(ctx, any_client_state.clone(), any_consensus_state.clone())
+        InnerLightClient
+            .create_client(ctx, any_client_state.clone(), any_consensus_state.clone())
             .map_err(|e| ClientError::CreateClient(e, any_client_state, any_consensus_state).into())
     }
 
@@ -59,7 +60,8 @@ impl LightClient for ParliaLightClient {
         client_id: ClientId,
         any_message: Any,
     ) -> Result<UpdateClientResult, LightClientError> {
-        self.process_update_client(ctx, client_id.clone(), any_message.clone())
+        InnerLightClient
+            .update_client(ctx, client_id.clone(), any_message.clone())
             .map_err(|e| ClientError::UpdateClient(e, client_id, any_message).into())
     }
 
@@ -73,19 +75,28 @@ impl LightClient for ParliaLightClient {
         proof_height: Height,
         proof: Vec<u8>,
     ) -> Result<VerifyMembershipResult, LightClientError> {
-        self.process_verify_membership(
-            ctx,
-            client_id.clone(),
-            prefix.clone(),
-            path.clone(),
-            value.clone(),
-            proof_height,
-            proof.clone(),
-        )
-        .map_err(|e| {
-            ClientError::VerifyMembership(e, client_id, prefix, path, value, proof_height, proof)
+        InnerLightClient
+            .verify_membership(
+                ctx,
+                client_id.clone(),
+                prefix.clone(),
+                path.clone(),
+                value.clone(),
+                proof_height,
+                proof.clone(),
+            )
+            .map_err(|e| {
+                ClientError::VerifyMembership(
+                    e,
+                    client_id,
+                    prefix,
+                    path,
+                    value,
+                    proof_height,
+                    proof,
+                )
                 .into()
-        })
+            })
     }
 
     fn verify_non_membership(
@@ -97,22 +108,26 @@ impl LightClient for ParliaLightClient {
         proof_height: Height,
         proof: Vec<u8>,
     ) -> Result<VerifyNonMembershipResult, LightClientError> {
-        self.process_verify_non_membership(
-            ctx,
-            client_id.clone(),
-            prefix.clone(),
-            path.clone(),
-            proof_height,
-            proof.clone(),
-        )
-        .map_err(|e| {
-            ClientError::VerifyNonMembership(e, client_id, prefix, path, proof_height, proof).into()
-        })
+        InnerLightClient
+            .verify_non_membership(
+                ctx,
+                client_id.clone(),
+                prefix.clone(),
+                path.clone(),
+                proof_height,
+                proof.clone(),
+            )
+            .map_err(|e| {
+                ClientError::VerifyNonMembership(e, client_id, prefix, path, proof_height, proof)
+                    .into()
+            })
     }
 }
 
-impl ParliaLightClient {
-    fn process_create_client(
+struct InnerLightClient;
+
+impl InnerLightClient {
+    fn create_client(
         &self,
         _ctx: &dyn HostClientReader,
         any_client_state: Any,
@@ -142,7 +157,7 @@ impl ParliaLightClient {
         })
     }
 
-    fn process_update_client(
+    fn update_client(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
@@ -167,7 +182,7 @@ impl ParliaLightClient {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn process_verify_membership(
+    fn verify_membership(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
@@ -199,7 +214,7 @@ impl ParliaLightClient {
         })
     }
 
-    fn process_verify_non_membership(
+    fn verify_non_membership(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
@@ -873,7 +888,7 @@ mod test {
             true,
         )
         .unwrap_err();
-        let expected = format!("{:?}", err).contains(" ClientFrozen: xx-parlia-0");
+        let expected = format!("{:?}", err).contains("ClientFrozen: xx-parlia-0");
         assert!(expected, "{}", err);
     }
 

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -18,7 +18,7 @@ use crate::commitment::{
     calculate_ibc_commitment_storage_key, decode_eip1184_rlp_proof, verify_proof,
 };
 use crate::consensus_state::ConsensusState;
-use crate::errors::Error;
+use crate::errors::{ClientError, Error};
 
 use crate::header::Header;
 use crate::message::ClientMessage;
@@ -38,16 +38,86 @@ impl LightClient for ParliaLightClient {
         client_id: &ClientId,
     ) -> Result<Height, LightClientError> {
         let any_client_state = ctx.client_state(client_id)?;
-        let client_state = ClientState::try_from(any_client_state)?;
+        let client_state = ClientState::try_from(any_client_state)
+            .map_err(|e| ClientError::LatestHeight(e, client_id.clone()))?;
         Ok(client_state.latest_height)
     }
 
     fn create_client(
         &self,
-        _ctx: &dyn HostClientReader,
+        ctx: &dyn HostClientReader,
         any_client_state: Any,
         any_consensus_state: Any,
     ) -> Result<CreateClientResult, LightClientError> {
+        self.process_create_client(ctx, any_client_state.clone(), any_consensus_state.clone())
+            .map_err(|e| ClientError::CreateClient(e, any_client_state, any_consensus_state).into())
+    }
+
+    fn update_client(
+        &self,
+        ctx: &dyn HostClientReader,
+        client_id: ClientId,
+        any_message: Any,
+    ) -> Result<UpdateClientResult, LightClientError> {
+        self.process_update_client(ctx, client_id.clone(), any_message.clone())
+            .map_err(|e| ClientError::UpdateClient(e, client_id, any_message).into())
+    }
+
+    fn verify_membership(
+        &self,
+        ctx: &dyn HostClientReader,
+        client_id: ClientId,
+        prefix: CommitmentPrefix,
+        path: String,
+        value: Vec<u8>,
+        proof_height: Height,
+        proof: Vec<u8>,
+    ) -> Result<VerifyMembershipResult, LightClientError> {
+        self.process_verify_membership(
+            ctx,
+            client_id.clone(),
+            prefix.clone(),
+            path.clone(),
+            value.clone(),
+            proof_height,
+            proof.clone(),
+        )
+        .map_err(|e| {
+            ClientError::VerifyMembership(e, client_id, prefix, path, value, proof_height, proof)
+                .into()
+        })
+    }
+
+    fn verify_non_membership(
+        &self,
+        ctx: &dyn HostClientReader,
+        client_id: ClientId,
+        prefix: CommitmentPrefix,
+        path: String,
+        proof_height: Height,
+        proof: Vec<u8>,
+    ) -> Result<VerifyNonMembershipResult, LightClientError> {
+        self.process_verify_non_membership(
+            ctx,
+            client_id.clone(),
+            prefix.clone(),
+            path.clone(),
+            proof_height,
+            proof.clone(),
+        )
+        .map_err(|e| {
+            ClientError::VerifyNonMembership(e, client_id, prefix, path, proof_height, proof).into()
+        })
+    }
+}
+
+impl ParliaLightClient {
+    fn process_create_client(
+        &self,
+        _ctx: &dyn HostClientReader,
+        any_client_state: Any,
+        any_consensus_state: Any,
+    ) -> Result<CreateClientResult, Error> {
         let client_state = ClientState::try_from(any_client_state.clone())?;
         let consensus_state = ConsensusState::try_from(any_consensus_state)?;
 
@@ -72,12 +142,12 @@ impl LightClient for ParliaLightClient {
         })
     }
 
-    fn update_client(
+    fn process_update_client(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
         any_message: Any,
-    ) -> Result<UpdateClientResult, LightClientError> {
+    ) -> Result<UpdateClientResult, Error> {
         match ClientMessage::try_from(any_message.clone())? {
             ClientMessage::Header(header) => Ok(self.update_state(ctx, client_id, header)?.into()),
             ClientMessage::Misbehaviour(misbehavior) => {
@@ -96,7 +166,8 @@ impl LightClient for ParliaLightClient {
         }
     }
 
-    fn verify_membership(
+    #[allow(clippy::too_many_arguments)]
+    fn process_verify_membership(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
@@ -105,7 +176,7 @@ impl LightClient for ParliaLightClient {
         value: Vec<u8>,
         proof_height: Height,
         proof: Vec<u8>,
-    ) -> Result<VerifyMembershipResult, LightClientError> {
+    ) -> Result<VerifyMembershipResult, Error> {
         let value = keccak_256(&value);
         let state_id = self.verify_commitment(
             ctx,
@@ -128,7 +199,7 @@ impl LightClient for ParliaLightClient {
         })
     }
 
-    fn verify_non_membership(
+    fn process_verify_non_membership(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
@@ -136,33 +207,33 @@ impl LightClient for ParliaLightClient {
         path: String,
         proof_height: Height,
         proof: Vec<u8>,
-    ) -> Result<VerifyNonMembershipResult, LightClientError> {
+    ) -> Result<VerifyNonMembershipResult, Error> {
         let state_id =
             self.verify_commitment(ctx, client_id, &prefix, &path, None, &proof_height, proof)?;
         Ok(VerifyNonMembershipResult {
             message: VerifyMembershipProxyMessage::new(prefix, path, None, proof_height, state_id),
         })
     }
-}
 
-impl ParliaLightClient {
     pub fn update_state(
         &self,
         ctx: &dyn HostClientReader,
         client_id: ClientId,
         header: Header,
-    ) -> Result<UpdateStateData, LightClientError> {
+    ) -> Result<UpdateStateData, Error> {
         //Ensure header can be verified.
         let height = header.height();
         let timestamp = header.timestamp()?;
         let trusted_height = header.trusted_height();
-        let any_client_state = ctx.client_state(&client_id)?;
-        let any_consensus_state = ctx.consensus_state(&client_id, &trusted_height)?;
+        let any_client_state = ctx.client_state(&client_id).map_err(Error::LCPError)?;
+        let any_consensus_state = ctx
+            .consensus_state(&client_id, &trusted_height)
+            .map_err(Error::LCPError)?;
 
         //Ensure client is not frozen
         let client_state = ClientState::try_from(any_client_state)?;
         if client_state.frozen {
-            return Err(Error::ClientFrozen(client_id).into());
+            return Err(Error::ClientFrozen(client_id));
         }
 
         // Create new state and ensure header is valid
@@ -207,16 +278,18 @@ impl ParliaLightClient {
         ctx: &dyn HostClientReader,
         client_id: ClientId,
         misbehaviour: Misbehaviour,
-    ) -> Result<(ClientState, Vec<PrevState>, ValidationContext), LightClientError> {
-        let any_client_state = ctx.client_state(&client_id)?;
-        let any_consensus_state1 =
-            ctx.consensus_state(&client_id, &misbehaviour.header_1.trusted_height())?;
-        let any_consensus_state2 =
-            ctx.consensus_state(&client_id, &misbehaviour.header_2.trusted_height())?;
+    ) -> Result<(ClientState, Vec<PrevState>, ValidationContext), Error> {
+        let any_client_state = ctx.client_state(&client_id).map_err(Error::LCPError)?;
+        let any_consensus_state1 = ctx
+            .consensus_state(&client_id, &misbehaviour.header_1.trusted_height())
+            .map_err(Error::LCPError)?;
+        let any_consensus_state2 = ctx
+            .consensus_state(&client_id, &misbehaviour.header_2.trusted_height())
+            .map_err(Error::LCPError)?;
 
         let client_state = ClientState::try_from(any_client_state)?;
         if client_state.frozen {
-            return Err(Error::ClientFrozen(client_id).into());
+            return Err(Error::ClientFrozen(client_id));
         }
 
         let trusted_consensus_state1 = ConsensusState::try_from(any_consensus_state1)?;
@@ -266,20 +339,24 @@ impl ParliaLightClient {
         value: Option<Vec<u8>>,
         proof_height: &Height,
         storage_proof_rlp: Vec<u8>,
-    ) -> Result<StateID, LightClientError> {
-        let client_state = ClientState::try_from(ctx.client_state(&client_id)?)?;
+    ) -> Result<StateID, Error> {
+        let client_state =
+            ClientState::try_from(ctx.client_state(&client_id).map_err(Error::LCPError)?)?;
         if client_state.frozen {
-            return Err(Error::ClientFrozen(client_id).into());
+            return Err(Error::ClientFrozen(client_id));
         }
         let proof_height = *proof_height;
         if client_state.latest_height < proof_height {
-            return Err(
-                Error::UnexpectedProofHeight(proof_height, client_state.latest_height).into(),
-            );
+            return Err(Error::UnexpectedProofHeight(
+                proof_height,
+                client_state.latest_height,
+            ));
         }
 
-        let consensus_state =
-            ConsensusState::try_from(ctx.consensus_state(&client_id, &proof_height)?)?;
+        let consensus_state = ConsensusState::try_from(
+            ctx.consensus_state(&client_id, &proof_height)
+                .map_err(Error::LCPError)?,
+        )?;
         let storage_root = consensus_state.state_root;
         let storage_proof = decode_eip1184_rlp_proof(&storage_proof_rlp)?;
         verify_proof(
@@ -299,11 +376,13 @@ impl ParliaLightClient {
         client_id: &ClientId,
         client_state: &ClientState,
         heights: Vec<Height>,
-    ) -> Result<Vec<PrevState>, LightClientError> {
+    ) -> Result<Vec<PrevState>, Error> {
         let mut prev_states = Vec::new();
         for height in heights {
-            let consensus_state: ConsensusState =
-                ctx.consensus_state(client_id, &height)?.try_into()?;
+            let consensus_state: ConsensusState = ctx
+                .consensus_state(client_id, &height)
+                .map_err(Error::LCPError)?
+                .try_into()?;
             prev_states.push(PrevState {
                 height,
                 state_id: gen_state_id(client_state.clone(), consensus_state)?,
@@ -316,10 +395,12 @@ impl ParliaLightClient {
 fn gen_state_id(
     client_state: ClientState,
     consensus_state: ConsensusState,
-) -> Result<StateID, LightClientError> {
+) -> Result<StateID, Error> {
     let client_state = Any::try_from(client_state.canonicalize())?;
     let consensus_state = Any::try_from(consensus_state.canonicalize())?;
-    gen_state_id_from_any(&client_state, &consensus_state).map_err(LightClientError::commitment)
+    gen_state_id_from_any(&client_state, &consensus_state)
+        .map_err(LightClientError::commitment)
+        .map_err(Error::LCPError)
 }
 
 #[cfg(test)]
@@ -412,7 +493,7 @@ mod test {
                 .client_state
                 .clone()
                 .ok_or_else(|| light_client::Error::client_state_not_found(client_id.clone()))?;
-            Ok(Any::try_from(cs)?)
+            Ok(Any::try_from(cs).unwrap())
         }
 
         fn consensus_state(
@@ -427,7 +508,7 @@ mod test {
                     light_client::Error::consensus_state_not_found(client_id.clone(), *height)
                 })?
                 .clone();
-            Ok(Any::try_from(state)?)
+            Ok(Any::try_from(state).unwrap())
         }
     }
 

--- a/light-client/src/commitment.rs
+++ b/light-client/src/commitment.rs
@@ -67,12 +67,12 @@ pub fn verify_proof(
     Ok(())
 }
 
-fn verify(root: &Hash, proof: &[Vec<u8>], key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+fn verify(raw_root: &Hash, proof: &[Vec<u8>], key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
     let db = StorageProof::new(proof.to_vec()).into_memory_db::<keccak::KeccakHasher>();
-    let root: primitive_types::H256 = root.into();
+    let root: primitive_types::H256 = raw_root.into();
     let trie = TrieDBBuilder::<EIP1186Layout<keccak::KeccakHasher>>::new(&db, &root).build();
     trie.get(&keccak_256(key))
-        .map_err(|e| Error::TrieError(e, root, proof.to_vec(), key.to_vec()))
+        .map_err(|e| Error::TrieError(e, *raw_root, proof.to_vec(), key.to_vec()))
 }
 
 fn trim_left_zero(value: &[u8]) -> &[u8] {

--- a/light-client/src/commitment.rs
+++ b/light-client/src/commitment.rs
@@ -71,7 +71,8 @@ fn verify(root: &Hash, proof: &[Vec<u8>], key: &[u8]) -> Result<Option<Vec<u8>>,
     let db = StorageProof::new(proof.to_vec()).into_memory_db::<keccak::KeccakHasher>();
     let root: primitive_types::H256 = root.into();
     let trie = TrieDBBuilder::<EIP1186Layout<keccak::KeccakHasher>>::new(&db, &root).build();
-    trie.get(&keccak_256(key)).map_err(Error::TrieError)
+    trie.get(&keccak_256(key))
+        .map_err(|e| Error::TrieError(e, root, proof.to_vec(), key.to_vec()))
 }
 
 fn trim_left_zero(value: &[u8]) -> &[u8] {

--- a/light-client/src/errors.rs
+++ b/light-client/src/errors.rs
@@ -380,17 +380,17 @@ impl core::fmt::Display for ClientError {
                 client_id
             } => write!(
                 f,
-                "LatestHeight: cause={}\n, client_id={}",
+                "LatestHeight: cause={}\nclient_id={}",
                 cause, client_id
             ),
             ClientError::CreateClient {cause, client_state, consensus_sate} => write!(
                 f,
-                "CreateClient: cause={}\n, client_state={:?}, consensus_state={:?}",
+                "CreateClient: cause={}\nclient_state={:?}\nconsensus_state={:?}",
                 cause, client_state, consensus_sate
             ),
             ClientError::UpdateClient{cause, client_id, message} => write!(
                 f,
-                "CreateClient: cause={}\n, client_id={:?}, message={:?}",
+                "CreateClient: cause={}\nclient_id={:?}\nmessage={:?}",
                 cause, client_id, message
             ),
             ClientError::VerifyMembership {
@@ -402,7 +402,7 @@ impl core::fmt::Display for ClientError {
                 proof
             } => write!(
                 f,
-                "VerifyMembership: cause={}\n, client_id={:?}, prefix={:?}, path={:?}, value={:?}, proof_height={:?}, proof={:?}",
+                "VerifyMembership: cause={}\nclient_id={:?}\nprefix={:?}\npath={:?}\nvalue={:?}\nproof_height={:?}\nproof={:?}",
                 cause, client_id, prefix, path, value, proof_height, proof
             ),
             ClientError::VerifyNonMembership {
@@ -413,7 +413,7 @@ impl core::fmt::Display for ClientError {
                 proof
             } => write!(
                 f,
-                "VerifyNonMembership: cause={}\n, client_id={:?}, prefix={:?}, path={:?}, proof_height={:?}, proof={:?}",
+                "VerifyNonMembership: cause={}\nclient_id={:?}\nprefix={:?}\npath={:?}\nproof_height={:?}\nproof={:?}",
                 cause, client_id, prefix, path, proof_height, proof
             ),
         }

--- a/light-client/src/errors.rs
+++ b/light-client/src/errors.rs
@@ -111,7 +111,8 @@ pub enum Error {
     UnexpectedClientId(String),
     UnexpectedDifferentHeight(Height, Height),
     UnexpectedSameBlockHash(Height),
-    TrieError(BoxedTrieError),
+
+    TrieError(BoxedTrieError, primitive_types::H256, Vec<Vec<u8>>, Vec<u8>),
 
     // Framework
     LCPError(light_client::Error),
@@ -210,8 +211,8 @@ impl core::fmt::Display for Error {
                     e1, e2, e3, e4, e5
                 )
             }
-            Error::TrieError(e1) => {
-                write!(f, "TrieError : {:?}", e1)
+            Error::TrieError(e1, e2, e3, e4) => {
+                write!(f, "TrieError : {:?} {:?} {:?} {:?}", e1, e2, e3, e4)
             }
             Error::InvalidProofFormatError(e1) => {
                 write!(f, "InvalidProofFormatError : {:?}", e1)

--- a/light-client/src/errors.rs
+++ b/light-client/src/errors.rs
@@ -339,59 +339,82 @@ impl core::fmt::Display for Error {
 
 #[derive(Debug)]
 pub enum ClientError {
-    LatestHeight(Error, ClientId),
-    CreateClient(Error, Any, Any),
-    UpdateClient(Error, ClientId, Any),
-    VerifyMembership(
-        Error,
-        ClientId,
-        CommitmentPrefix,
-        String,
-        Vec<u8>,
-        Height,
-        Vec<u8>,
-    ),
-    VerifyNonMembership(Error, ClientId, CommitmentPrefix, String, Height, Vec<u8>),
+    LatestHeight {
+        cause: Error,
+        client_id: ClientId,
+    },
+    CreateClient {
+        cause: Error,
+        client_state: Any,
+        consensus_sate: Any,
+    },
+    UpdateClient {
+        cause: Error,
+        client_id: ClientId,
+        message: Any,
+    },
+    VerifyMembership {
+        cause: Error,
+        client_id: ClientId,
+        prefix: CommitmentPrefix,
+        path: String,
+        value: Vec<u8>,
+        proof_height: Height,
+        proof: Vec<u8>,
+    },
+    VerifyNonMembership {
+        cause: Error,
+        client_id: ClientId,
+        prefix: CommitmentPrefix,
+        path: String,
+        proof_height: Height,
+        proof: Vec<u8>,
+    },
 }
 
 impl core::fmt::Display for ClientError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
-            ClientError::LatestHeight(e, client_id) => write!(
+            ClientError::LatestHeight {
+                cause,
+                client_id
+            } => write!(
                 f,
-                "LatestHeight: cause={}\n, client_id={:?}",
-                e, client_id
+                "LatestHeight: cause={}\n, client_id={}",
+                cause, client_id
             ),
-            ClientError::CreateClient(e, any_client_state, any_consensus_state) => write!(
+            ClientError::CreateClient {cause, client_state, consensus_sate} => write!(
                 f,
-                "CreateClient: cause={}\n, any_client_state={:?}, any_consensus_state={:?}",
-                e, any_client_state, any_consensus_state
+                "CreateClient: cause={}\n, client_state={:?}, consensus_state={:?}",
+                cause, client_state, consensus_sate
             ),
-            ClientError::UpdateClient(e, client_id, message) => write!(
+            ClientError::UpdateClient{cause, client_id, message} => write!(
                 f,
                 "CreateClient: cause={}\n, client_id={:?}, message={:?}",
-                e, client_id, message
+                cause, client_id, message
             ),
-            ClientError::VerifyMembership(e,  client_id,
-                                          prefix,
-                                          path,
-                                          value,
-                                          proof_height,
-                                          proof
-            ) => write!(
+            ClientError::VerifyMembership {
+                cause, client_id,
+                prefix,
+                path,
+                value,
+                proof_height,
+                proof
+            } => write!(
                 f,
                 "VerifyMembership: cause={}\n, client_id={:?}, prefix={:?}, path={:?}, value={:?}, proof_height={:?}, proof={:?}",
-                e, client_id, prefix, path, value, proof_height, proof
+                cause, client_id, prefix, path, value, proof_height, proof
             ),
-            ClientError::VerifyNonMembership(e,  client_id,
-                                          prefix,
-                                          path,
-                                          proof_height,
-                                          proof
-            ) => write!(
+            ClientError::VerifyNonMembership {
+                cause, client_id,
+                prefix,
+                path,
+                proof_height,
+                proof
+            } => write!(
                 f,
                 "VerifyNonMembership: cause={}\n, client_id={:?}, prefix={:?}, path={:?}, proof_height={:?}, proof={:?}",
-                e, client_id, prefix, path, proof_height, proof
+                cause, client_id, prefix, path, proof_height, proof
             ),
         }
     }

--- a/light-client/src/errors.rs
+++ b/light-client/src/errors.rs
@@ -112,7 +112,7 @@ pub enum Error {
     UnexpectedDifferentHeight(Height, Height),
     UnexpectedSameBlockHash(Height),
 
-    TrieError(BoxedTrieError, primitive_types::H256, Vec<Vec<u8>>, Vec<u8>),
+    TrieError(BoxedTrieError, Hash, Vec<Vec<u8>>, Vec<u8>),
 
     // Framework
     LCPError(light_client::Error),


### PR DESCRIPTION
If an error occurs, wrap the original error and include the LightClient arguments in the error.

```rust 
pub enum ClientError {
    LatestHeight {
        cause: Error,
        client_id: ClientId,
    },
    CreateClient {
        cause: Error,
        client_state: Any,
        consensus_sate: Any,
    },
    UpdateClient {
        cause: Error,
        client_id: ClientId,
        message: Any,
    },
    VerifyMembership {
        cause: Error,
        client_id: ClientId,
        prefix: CommitmentPrefix,
        path: String,
        value: Vec<u8>,
        proof_height: Height,
        proof: Vec<u8>,
    },
    VerifyNonMembership {
        cause: Error,
        client_id: ClientId,
        prefix: CommitmentPrefix,
        path: String,
        proof_height: Height,
        proof: Vec<u8>,
    },
}
```