### PR TITLE
Fix bohr block decode

### DIFF
--- a/light-client/src/header/eth_header.rs
+++ b/light-client/src/header/eth_header.rs
@@ -287,16 +287,14 @@ impl ETHHeader {
             &self.extra_data[EXTRA_VANITY..self.extra_data.len() - EXTRA_SEAL]
         } else {
             let num = self.extra_data[EXTRA_VANITY] as usize;
-            if self.extra_data.len()
-                <= EXTRA_VANITY + EXTRA_SEAL + VALIDATOR_NUM_SIZE + num * VALIDATOR_BYTES_LENGTH
-            {
-                return Err(Error::UnexpectedVoteLength(self.extra_data.len()));
-            }
             let start = EXTRA_VANITY
                 + VALIDATOR_NUM_SIZE
                 + (num * VALIDATOR_BYTES_LENGTH)
                 + TURN_LENGTH_SIZE;
             let end = self.extra_data.len() - EXTRA_SEAL;
+            if end <= start {
+                return Err(Error::UnexpectedVoteLength(self.extra_data.len()));
+            }
             &self.extra_data[start..end]
         };
 
@@ -313,7 +311,7 @@ pub fn get_validator_bytes_and_tern_term(extra_data: &[u8]) -> Result<(Validator
         return Err(Error::UnexpectedExtraDataLength(extra_data.len()));
     }
     let num = extra_data[EXTRA_VANITY] as usize;
-    if num == 0 || extra_data.len() <= EXTRA_VANITY + EXTRA_SEAL + num * VALIDATOR_BYTES_LENGTH {
+    if num == 0 || extra_data.len() < EXTRA_VANITY + EXTRA_SEAL + num * VALIDATOR_BYTES_LENGTH {
         return Err(Error::UnexpectedExtraDataLength(extra_data.len()));
     }
     let start = EXTRA_VANITY + VALIDATOR_NUM_SIZE;

--- a/light-client/src/header/vote_attestation.rs
+++ b/light-client/src/header/vote_attestation.rs
@@ -148,6 +148,7 @@ impl<'a> TryFrom<Rlp<'a>> for VoteAttestation {
 mod test {
     use crate::errors::Error;
     use crate::fixture::*;
+    use crate::header::eth_header::{get_validator_bytes_and_tern_term, ETHHeader};
     use crate::header::vote_attestation::{
         VoteAddressBitSet, VoteAttestation, VoteData, BLS_SIGNATURE_LENGTH,
         MAX_ATTESTATION_EXTRA_LENGTH,
@@ -209,6 +210,44 @@ mod test {
         for block in blocks.iter() {
             let vote = block.get_vote_attestation().unwrap();
             vote.verify(block.number, &validators).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_error_no_vote_data() {
+        let header = ETHHeader {
+            parent_hash: vec![],
+            uncle_hash: vec![],
+            coinbase: vec![],
+            root:  [0u8; 32],
+            tx_hash: vec![],
+            receipt_hash: vec![],
+            bloom: vec![],
+            difficulty: 0,
+            number: 43198800,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 0,
+            extra_data: hex!("d98301040d846765746889676f312e32312e3132856c696e757800000299d9bc0808265da01e1a65d62b903c7b34c08cb389bf3d9996f763f030b1adcfb369c5a5df4a18e1529baffe7feaec66db3dbd1bc06810f7f6f88b7be6645418a7e2a2a3f40514c215a13e315cbfb9398a26d77a299963bf034c28f8b0183ea044211f468630233d2533b73307979c78a9486b33bb4ee04ca31a65f3e86fba804db7fe293fa643e6b72bb3821a3d9d7a717d64e6088ac937d5aacdd3e20ca963979974cd8ff90cbf097023dc8c448245ceff671e965d57d82eaf9be91478cfa0f24d2993e0c5f43a6c5a4cd99850023040d3256eb0babe89f0ea54edaa398513136612f5a334b49d766ebe3eb9f6bdc163bd2c19aa7e8cee1667851ae0c1651f01c4cf7cf2cfcf8475bff3e99cab25b05631472d53387f3321fd69d1e030bb921230dfb188826affaa39ebf1c38b190851e4db0588a3e90142c5299041fb8a0db3bb9a1fa4bdf0dae84ca37ee12a6b8c26caab775f0e007b76d76ee8823de52a1a431884c2ca930c5e72bff3803af79641cf964cc001671017f0b680f93b7dde085b24bbc67b2a562a216f903ac878c5477641328172a353f1e493cf7f5f2cf1aec83bf0c74df566a41aa7ed65ea84ea99e3849ef31887c0f880a0feb92f356f58fbd023a82f5311fc87a5883a662e9ebbbefc90bf13aa533c2438a4113804bfd447b49cd040d20bc21e49ffea6487f5638e4346ad9fc6d1ec30e28016d3892b51a7898bd354cfe78643453fd3868410da412de7f2883180d0a2840111ad2e043fa403eb04cc3c0ed356ea54a6e7015490240681b002cb63e12f65c456cafca335c730b123553e70df5322013812429e0bc31508e1f1fbf0ab312e4aaade9e022150071a1f00").into(),
+            mix_digest: vec![],
+            nonce: vec![],
+            base_fee_per_gas: None,
+            withdrawals_hash: None,
+            blob_gas_used: None,
+            excess_blob_gas: None,
+            parent_beacon_root: None,
+            hash: [0u8; 32],
+            epoch: None,
+        };
+        let (val, turn) = get_validator_bytes_and_tern_term(&header.extra_data).unwrap();
+        assert_eq!(val.len(), 8);
+        assert_eq!(turn, 4);
+        let err = header.get_vote_attestation().unwrap_err();
+        match err {
+            Error::UnexpectedVoteLength(size) => {
+                assert_eq!(header.extra_data.len(), size);
+            }
+            _ => unreachable!("invalid error{:?}", err),
         }
     }
 


### PR DESCRIPTION
Support no vote data in epoch after Bohr. 
ex)  https://testnet.bscscan.com/block/43198800