### PR TITLE
BELC3 & BELC4

### DIFF
--- a/light-client/src/client_state.rs
+++ b/light-client/src/client_state.rs
@@ -159,6 +159,13 @@ impl TryFrom<RawClientState> for ClientState {
 
         let chain_id = ChainId::new(value.chain_id);
 
+        if chain_id.version() != raw_latest_height.revision_number {
+            return Err(Error::UnexpectedLatestHeightRevision(
+                chain_id.version(),
+                raw_latest_height.revision_number,
+            ));
+        }
+
         let latest_height = new_height(
             raw_latest_height.revision_number,
             raw_latest_height.revision_height,
@@ -486,6 +493,19 @@ mod test {
         let err = ClientState::try_from(cs.clone()).unwrap_err();
         match err {
             Error::MissingLatestHeight => {}
+            err => unreachable!("{:?}", err),
+        }
+
+        cs.latest_height = Some(Height {
+            revision_number: 1,
+            revision_height: 0,
+        });
+        let err = ClientState::try_from(cs.clone()).unwrap_err();
+        match err {
+            Error::UnexpectedLatestHeightRevision(e1, e2) => {
+                assert_eq!(e1, 0);
+                assert_eq!(e2, 1);
+            }
             err => unreachable!("{:?}", err),
         }
 

--- a/light-client/src/errors.rs
+++ b/light-client/src/errors.rs
@@ -60,6 +60,7 @@ pub enum Error {
     UnexpectedTrustedHeight(BlockNumber, BlockNumber),
     EmptyHeader,
     UnexpectedHeaderRevision(u64, u64),
+    UnexpectedLatestHeightRevision(u64, u64),
     UnexpectedSignature(BlockNumber, signature::Error),
     MissingVanityInExtraData(BlockNumber, usize, usize),
     MissingSignatureInExtraData(BlockNumber, usize, usize),
@@ -162,6 +163,9 @@ impl core::fmt::Display for Error {
             Error::EmptyHeader => write!(f, "EmptyHeader"),
             Error::UnexpectedHeaderRevision(e1, e2) => {
                 write!(f, "UnexpectedHeaderRevision: {} {}", e1, e2)
+            }
+            Error::UnexpectedLatestHeightRevision(e1, e2) => {
+                write!(f, "UnexpectedLatestHeightRevision: {} {}", e1, e2)
             }
             Error::UnexpectedSignature(e1, e2) => write!(f, "UnexpectedSignature: {} {}", e1, e2),
             Error::MissingVanityInExtraData(e1, e2, e3) => {


### PR DESCRIPTION
Whenever instantiating a new ClientState , validate that chain_id.version and latest_height.revision_number are the same.